### PR TITLE
Autocomplete plainlist custom

### DIFF
--- a/src/components/autocomplete/Autocomplete.tsx
+++ b/src/components/autocomplete/Autocomplete.tsx
@@ -12,10 +12,8 @@ import RelationalList, { IRelationalListData } from './datatypes/RelationalList'
 // CSS styles
 import './autocomplete.scss'
 
-type IDataSource<T> = IGroupedData<T> | IRelationalListData<T> | IPlainListData<T>
-
 type IProps<T> = {
-  source: IDataSource<T>
+  source: IGroupedData<T> | IRelationalListData<T> | IPlainListData<T>
   selected: IInput<T> | null
   onChange?: (search: string) => void
   onSelect: (t: IInput<T> | null | undefined) => void
@@ -40,7 +38,7 @@ type IState<T> = {
 
   items: Groups<T> | RelationalList<T> | PlainList<T>
   lastSelected: IInput<T> | null
-  lastSourceData: IDataSource<T>['data']
+  lastSourceData: IProps<T>['source']['data']
 }
 
 function assertNever(x: never): never {
@@ -319,6 +317,7 @@ export class Autocomplete<T> extends React.Component<IProps<T>, IState<T>> {
                 mouseEnterRef={this.highlighted.setHighlighted}
                 suggestionsRef={this.highlighted.setSuggestionsContainerElement}
                 disableMatchHighlighting={disableMatchHighlighting}
+                customRenderer={this.props.source.customRenderer}
               />
             )) ||
             // Relational list suggestions

--- a/src/components/autocomplete/components/SuggestionsByPlainList.tsx
+++ b/src/components/autocomplete/components/SuggestionsByPlainList.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react'
 
-import PlainList from '../datatypes/PlainList'
+import PlainList, { CustomeRenderer } from '../datatypes/PlainList'
 import ISuggestionsBy from './ISuggestionsBy'
 import SuggestionItem from './SuggestionItem'
 
-type IProps<T> = ISuggestionsBy<PlainList<T>, T>
+type IProps<T> = ISuggestionsBy<PlainList<T>, T> & {
+  customRenderer?: CustomeRenderer<T>
+}
 
 export const SuggestionByPlainList: React.SFC<IProps<any>> = ({
   data: list,
@@ -14,21 +16,32 @@ export const SuggestionByPlainList: React.SFC<IProps<any>> = ({
   highlightedRef,
   mouseEnterRef,
   suggestionsRef,
-  disableMatchHighlighting
+  disableMatchHighlighting,
+  customRenderer
 }) => (
   <div className="react-autocomplete__list react-autocomplete__list--visible" ref={suggestionsRef}>
     {list.items.toJs.map(item => (
       <div key={item.id}>
-        <SuggestionItem
-          item={item}
-          search={search}
-          className="react-autocomplete__list-item"
-          selected={!!highlighted && highlighted.id === item.id}
-          itemRef={!!highlighted && highlighted.id === item.id ? highlightedRef : undefined}
-          onClick={_ => onClick(item.id)}
-          onMouseEnter={mouseEnterRef(item.toJS)}
-          disableMatchHighlighting={disableMatchHighlighting}
-        />
+        {customRenderer !== undefined ? (
+          customRenderer({
+            item,
+            onClick: () => onClick(item.id),
+            // mouseEnterRef(item.toJS),
+            selected: !!highlighted && highlighted.id === item.id,
+            search
+          })
+        ) : (
+          <SuggestionItem
+            item={item}
+            search={search}
+            className="react-autocomplete__list-item"
+            selected={!!highlighted && highlighted.id === item.id}
+            itemRef={!!highlighted && highlighted.id === item.id ? highlightedRef : undefined}
+            onClick={_ => onClick(item.id)}
+            onMouseEnter={mouseEnterRef(item.toJS)}
+            disableMatchHighlighting={disableMatchHighlighting}
+          />
+        )}
       </div>
     ))}
   </div>

--- a/src/components/autocomplete/components/SuggestionsByPlainList.tsx
+++ b/src/components/autocomplete/components/SuggestionsByPlainList.tsx
@@ -21,15 +21,25 @@ export const SuggestionByPlainList: React.SFC<IProps<any>> = ({
 }) => (
   <div className="react-autocomplete__list react-autocomplete__list--visible" ref={suggestionsRef}>
     {list.items.toJs.map(item => (
-      <div key={item.id}>
+      <ul>
         {customRenderer !== undefined ? (
-          customRenderer({
-            item,
-            onClick: () => onClick(item.id),
-            // mouseEnterRef(item.toJS),
-            selected: !!highlighted && highlighted.id === item.id,
-            search
-          })
+          // We wire up the mouseEnter/itemRef on the wrapping element so the custom renderer doesn't have to worry about it
+          <li
+            key={item.id}
+            onMouseEnter={(e: React.MouseEvent<HTMLLIElement>) =>
+              mouseEnterRef && mouseEnterRef(item.toJS)(e.currentTarget)
+            }
+            ref={(r: HTMLLIElement) =>
+              !!highlighted && highlighted.id === item.id && r ? highlightedRef(r) : undefined
+            }
+          >
+            {customRenderer({
+              item,
+              search,
+              onClick: () => onClick(item.id),
+              selected: !!highlighted && highlighted.id === item.id
+            })}
+          </li>
         ) : (
           <SuggestionItem
             item={item}
@@ -42,7 +52,7 @@ export const SuggestionByPlainList: React.SFC<IProps<any>> = ({
             disableMatchHighlighting={disableMatchHighlighting}
           />
         )}
-      </div>
+      </ul>
     ))}
   </div>
 )

--- a/src/components/autocomplete/datatypes/PlainList.ts
+++ b/src/components/autocomplete/datatypes/PlainList.ts
@@ -10,7 +10,6 @@ export type CustomeRenderer<T> = (
   props: {
     item: IPlainItem<T>
     onClick: () => void
-    // onMouseEnter: () => void,
     selected: boolean
     search: string | null
   }

--- a/src/components/autocomplete/datatypes/PlainList.ts
+++ b/src/components/autocomplete/datatypes/PlainList.ts
@@ -6,6 +6,16 @@ export type IImmutablePlainList<T> = List<IImmutablePlainItem<T>>
 
 export type IImmutablePlainItem<T> = RecordR<IPlainItem<T>>
 
+export type CustomeRenderer<T> = (
+  props: {
+    item: IPlainItem<T>
+    onClick: () => void
+    // onMouseEnter: () => void,
+    selected: boolean
+    search: string | null
+  }
+) => JSX.Element
+
 export type IPlainItem<T> = {
   id: T
   label: string
@@ -16,6 +26,10 @@ export type IPlainList<T> = Array<IPlainItem<T>>
 export type IPlainListData<T> = {
   type: 'plainList'
   data: IPlainList<T>
+  /**
+   * A custom renderer used to render each of the items
+   */
+  customRenderer?: CustomeRenderer<T>
 }
 
 const PlainItemToInput = <T>(item: IImmutablePlainItem<T>): IImmutableInput<T> =>

--- a/stories/autocomplete.stories.tsx
+++ b/stories/autocomplete.stories.tsx
@@ -5,12 +5,12 @@ import { boolean, number, text, withKnobs } from '@storybook/addon-knobs'
 import { addDecorator, storiesOf } from '@storybook/react'
 import React from 'react'
 import { Autocomplete } from '../src/components/autocomplete/Autocomplete'
-import PlainList from '../src/components/autocomplete/datatypes/PlainList'
+import PlainList, { CustomeRenderer, IPlainItem } from '../src/components/autocomplete/datatypes/PlainList'
 
 storiesOf('Core|Organisms/Autocomplete', module)
   .addDecorator(withKnobs)
   .add(
-    'Plain List',
+    'Flat List',
     withState({ selected: null as any }, store => (
       <div>
         <h4 className="sc-font-l">Plain list</h4>
@@ -35,7 +35,35 @@ storiesOf('Core|Organisms/Autocomplete', module)
       </div>
     ))
   )
-
+  .add(
+    'Custom Flat List',
+    withState({ selected: null as any }, store => (
+      <div>
+        <h4 className="sc-font-l">Flat Custom list</h4>
+        <blockquote>
+          Flat list of items w/ customized renderer<br />
+          <br />
+        </blockquote>
+        <Autocomplete
+          source={{
+            ...props.source,
+            customRenderer: FlatListRenderer
+          }}
+          selected={store.state.selected}
+          onChange={action('search term changed')}
+          onSelect={i => {
+            store.set({ selected: i })
+            action(`entry selected`)(i)
+          }}
+          disabled={boolean('disabled', false)}
+          placeholder={text('placeholder', props.placeholder)}
+          suppressErrors={boolean('suppressErrors', false)}
+          errorMessage={text('errorMessage', 'no matches for term')}
+          hideArrow={boolean('hideArrow', false)}
+        />
+      </div>
+    ))
+  )
   .add(
     'Relational List',
     withState({ selected: null as any }, store => (
@@ -95,31 +123,38 @@ const sources = {
   plain: [
     {
       id: 1,
-      label: 'john'
+      label: 'john',
+      avatar: 'https://wiki.teamfortress.com/w/images/6/67/Scoutava.jpg'
     },
     {
       id: 2,
-      label: 'johnny'
+      label: 'johnny',
+      avatar: 'https://wiki.teamfortress.com/w/images/f/f2/Soldierava.jpg'
     },
     {
       id: 3,
-      label: 'joe'
+      label: 'joe',
+      avatar: 'https://wiki.teamfortress.com/w/images/4/4b/Demomanava.jpg'
     },
     {
       id: 4,
-      label: 'johnannes'
+      label: 'johnannes',
+      avatar: 'https://wiki.teamfortress.com/w/images/5/5e/Heavyava.jpg'
     },
     {
       id: 5,
-      label: 'mike'
+      label: 'mike',
+      avatar: 'https://wiki.teamfortress.com/w/images/7/7f/Medicava.jpg'
     },
     {
       id: 6,
-      label: 'steve'
+      label: 'steve',
+      avatar: 'https://wiki.teamfortress.com/w/images/4/44/Sniperava.jpg'
     },
     {
       id: 7,
-      label: 'peter'
+      label: 'peter',
+      avatar: 'https://wiki.teamfortress.com/w/images/3/37/Spyava.jpg'
     }
   ],
   relational: [
@@ -223,4 +258,40 @@ const props = {
   suppressErrors: false,
   errorMessage: 'not match',
   hideArrow: false
+}
+
+const FlatListRenderer: CustomeRenderer<number> = p => {
+  return (
+    <div
+      onClick={p.onClick}
+      style={{
+        backgroundColor: p.selected ? 'rgba(0,0,0,0.2)' : 'transparent',
+        display: 'flex',
+        padding: '0.5em',
+        borderBottom: '1px solid #ccc'
+      }}
+    >
+      <img
+        style={{
+          maxWidth: '50px',
+          maxHeight: '50px',
+          borderRadius: '30px',
+          marginRight: '0.7em'
+        }}
+        src={sources.plain.filter(s => s.id === p.item.id)[0].avatar}
+      />
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center'
+        }}
+      >
+        <h3 style={{ fontWeight: 'bold', fontSize: '1.1em', marginBottom: '0.1em', textTransform: 'capitalize' }}>
+          {p.item.label}
+        </h3>
+        <p style={{ color: '#999', fontSize: '0.9em' }}>Some text about {p.item.label} here </p>
+      </div>
+    </div>
+  )
 }

--- a/stories/autocomplete/FlatListCustomRenderers.tsx
+++ b/stories/autocomplete/FlatListCustomRenderers.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import PlainList, { CustomeRenderer, IPlainItem } from '../../src/components/autocomplete/datatypes/PlainList'
+import { flat as flatData } from './data'
+
+export const IconizedRenderer: CustomeRenderer<number> = p => {
+  return (
+    <div
+      onClick={p.onClick}
+      style={{
+        backgroundColor: p.selected ? 'rgba(0,0,0,0.2)' : 'transparent',
+        display: 'flex',
+        padding: '0.5em',
+        borderBottom: '1px solid #ccc'
+      }}
+    >
+      <img
+        style={{
+          maxWidth: '50px',
+          maxHeight: '50px',
+          borderRadius: '30px',
+          marginRight: '0.7em'
+        }}
+        src={flatData.filter(s => s.id === p.item.id)[0].avatar}
+      />
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center'
+        }}
+      >
+        <h3 style={{ fontWeight: 'bold', fontSize: '1.1em', marginBottom: '0.1em', textTransform: 'capitalize' }}>
+          {p.item.label}
+        </h3>
+        <p style={{ color: '#999', fontSize: '0.9em' }}>Some text about {p.item.label} here </p>
+      </div>
+    </div>
+  )
+}

--- a/stories/autocomplete/FlatListCustomRenderers.tsx
+++ b/stories/autocomplete/FlatListCustomRenderers.tsx
@@ -37,3 +37,40 @@ export const IconizedRenderer: CustomeRenderer<number> = p => {
     </div>
   )
 }
+
+export const ThumbnailRenderer: CustomeRenderer<number> = p => {
+  return (
+    <div
+      onClick={p.onClick}
+      style={{
+        backgroundColor: p.selected ? 'rgba(0,0,0,0.2)' : 'transparent',
+        display: 'flex',
+        padding: '0.5em',
+        borderBottom: '1px solid #ccc',
+        cursor: 'pointer'
+      }}
+    >
+      <img
+        style={{
+          maxWidth: '120px',
+          maxHeight: '120px',
+          borderRadius: '10px',
+          marginRight: '0.7em'
+        }}
+        src={flatData.filter(s => s.id === p.item.id)[0].avatar}
+      />
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center'
+        }}
+      >
+        <h3 style={{ fontWeight: 'bold', fontSize: '1.1em', marginBottom: '0.1em', textTransform: 'capitalize' }}>
+          {p.item.label}
+        </h3>
+        <p style={{ color: '#999', fontSize: '0.9em' }}>Some text about {p.item.label} here </p>
+      </div>
+    </div>
+  )
+}

--- a/stories/autocomplete/autocomplete.stories.tsx
+++ b/stories/autocomplete/autocomplete.stories.tsx
@@ -4,8 +4,10 @@ import { withInfo } from '@storybook/addon-info'
 import { boolean, number, text, withKnobs } from '@storybook/addon-knobs'
 import { addDecorator, storiesOf } from '@storybook/react'
 import React from 'react'
-import { Autocomplete } from '../src/components/autocomplete/Autocomplete'
-import PlainList, { CustomeRenderer, IPlainItem } from '../src/components/autocomplete/datatypes/PlainList'
+import { Autocomplete } from '../../src/components/autocomplete/Autocomplete'
+import PlainList, { CustomeRenderer, IPlainItem } from '../../src/components/autocomplete/datatypes/PlainList'
+import { flat as flatData, group as groupData, relational as relationalData } from './data'
+import { IconizedRenderer } from './FlatListCustomRenderers'
 
 storiesOf('Core|Organisms/Autocomplete', module)
   .addDecorator(withKnobs)
@@ -47,7 +49,7 @@ storiesOf('Core|Organisms/Autocomplete', module)
         <Autocomplete
           source={{
             ...props.source,
-            customRenderer: FlatListRenderer
+            customRenderer: IconizedRenderer
           }}
           selected={store.state.selected}
           onChange={action('search term changed')}
@@ -74,7 +76,7 @@ storiesOf('Core|Organisms/Autocomplete', module)
           <br />
         </blockquote>
         <Autocomplete
-          source={{ type: 'relationalList', data: sources.relational }}
+          source={{ type: 'relationalList', data: relationalData }}
           selected={store.state.selected}
           onChange={action('search term changed')}
           onSelect={i => {
@@ -100,7 +102,7 @@ storiesOf('Core|Organisms/Autocomplete', module)
           <br />
         </blockquote>
         <Autocomplete
-          source={{ type: 'grouped', data: sources.groups }}
+          source={{ type: 'grouped', data: groupData }}
           selected={store.state.selected}
           onChange={action('search term changed')}
           onSelect={i => {
@@ -119,132 +121,10 @@ storiesOf('Core|Organisms/Autocomplete', module)
   .addDecorator(withInfo({ inline: true, header: false, source: false })(() => <Autocomplete {...props} />))
   .add('usage', () => <div />)
 
-const sources = {
-  plain: [
-    {
-      id: 1,
-      label: 'john',
-      avatar: 'https://wiki.teamfortress.com/w/images/6/67/Scoutava.jpg'
-    },
-    {
-      id: 2,
-      label: 'johnny',
-      avatar: 'https://wiki.teamfortress.com/w/images/f/f2/Soldierava.jpg'
-    },
-    {
-      id: 3,
-      label: 'joe',
-      avatar: 'https://wiki.teamfortress.com/w/images/4/4b/Demomanava.jpg'
-    },
-    {
-      id: 4,
-      label: 'johnannes',
-      avatar: 'https://wiki.teamfortress.com/w/images/5/5e/Heavyava.jpg'
-    },
-    {
-      id: 5,
-      label: 'mike',
-      avatar: 'https://wiki.teamfortress.com/w/images/7/7f/Medicava.jpg'
-    },
-    {
-      id: 6,
-      label: 'steve',
-      avatar: 'https://wiki.teamfortress.com/w/images/4/44/Sniperava.jpg'
-    },
-    {
-      id: 7,
-      label: 'peter',
-      avatar: 'https://wiki.teamfortress.com/w/images/3/37/Spyava.jpg'
-    }
-  ],
-  relational: [
-    {
-      id: -1,
-      label: 'Aaron'
-    },
-    {
-      id: 0,
-      label: 'Jay (all J belong to me)'
-    },
-    {
-      id: 1,
-      label: 'john',
-      parentId: 0
-    },
-    {
-      id: 2,
-      label: 'johnny',
-      parentId: 0
-    },
-    {
-      id: 3,
-      label: 'joe',
-      parentId: 0
-    },
-    {
-      id: 4,
-      label: 'johnannes',
-      parentId: 0
-    },
-    {
-      id: 5,
-      label: 'mike'
-    },
-    {
-      id: 6,
-      label: 'steve'
-    },
-    {
-      id: 7,
-      label: 'peter'
-    }
-  ],
-  groups: [
-    {
-      label: 'J names',
-      items: [
-        {
-          id: 1,
-          label: 'john'
-        },
-        {
-          id: 2,
-          label: 'johnny'
-        },
-        {
-          id: 3,
-          label: 'joe'
-        },
-        {
-          id: 4,
-          label: 'johnannes'
-        }
-      ]
-    },
-    {
-      label: 'Other names',
-      items: [
-        {
-          id: 5,
-          label: 'mike'
-        },
-        {
-          id: 6,
-          label: 'steve'
-        },
-        {
-          id: 7,
-          label: 'peter'
-        }
-      ]
-    }
-  ]
-}
-
 const props = {
   source: {
     type: 'plainList' as 'plainList',
-    data: sources.plain
+    data: flatData
   },
   selected: null,
   onChange: (search: string) => {
@@ -258,40 +138,4 @@ const props = {
   suppressErrors: false,
   errorMessage: 'not match',
   hideArrow: false
-}
-
-const FlatListRenderer: CustomeRenderer<number> = p => {
-  return (
-    <div
-      onClick={p.onClick}
-      style={{
-        backgroundColor: p.selected ? 'rgba(0,0,0,0.2)' : 'transparent',
-        display: 'flex',
-        padding: '0.5em',
-        borderBottom: '1px solid #ccc'
-      }}
-    >
-      <img
-        style={{
-          maxWidth: '50px',
-          maxHeight: '50px',
-          borderRadius: '30px',
-          marginRight: '0.7em'
-        }}
-        src={sources.plain.filter(s => s.id === p.item.id)[0].avatar}
-      />
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          justifyContent: 'center'
-        }}
-      >
-        <h3 style={{ fontWeight: 'bold', fontSize: '1.1em', marginBottom: '0.1em', textTransform: 'capitalize' }}>
-          {p.item.label}
-        </h3>
-        <p style={{ color: '#999', fontSize: '0.9em' }}>Some text about {p.item.label} here </p>
-      </div>
-    </div>
-  )
 }

--- a/stories/autocomplete/autocomplete.stories.tsx
+++ b/stories/autocomplete/autocomplete.stories.tsx
@@ -7,7 +7,7 @@ import React from 'react'
 import { Autocomplete } from '../../src/components/autocomplete/Autocomplete'
 import PlainList, { CustomeRenderer, IPlainItem } from '../../src/components/autocomplete/datatypes/PlainList'
 import { flat as flatData, group as groupData, relational as relationalData } from './data'
-import { IconizedRenderer } from './FlatListCustomRenderers'
+import { IconizedRenderer, ThumbnailRenderer } from './FlatListCustomRenderers'
 
 storiesOf('Core|Organisms/Autocomplete', module)
   .addDecorator(withKnobs)
@@ -39,32 +39,97 @@ storiesOf('Core|Organisms/Autocomplete', module)
   )
   .add(
     'Custom Flat List',
-    withState({ selected: null as any }, store => (
-      <div>
-        <h4 className="sc-font-l">Flat Custom list</h4>
-        <blockquote>
-          Flat list of items w/ customized renderer<br />
-          <br />
-        </blockquote>
-        <Autocomplete
-          source={{
-            ...props.source,
-            customRenderer: IconizedRenderer
-          }}
-          selected={store.state.selected}
-          onChange={action('search term changed')}
-          onSelect={i => {
-            store.set({ selected: i })
-            action(`entry selected`)(i)
-          }}
-          disabled={boolean('disabled', false)}
-          placeholder={text('placeholder', props.placeholder)}
-          suppressErrors={boolean('suppressErrors', false)}
-          errorMessage={text('errorMessage', 'no matches for term')}
-          hideArrow={boolean('hideArrow', false)}
-        />
-      </div>
-    ))
+    withState({ selected: null as any, renderer: 'icon' }, store => {
+      const renderers = {
+        icon: IconizedRenderer,
+        thumbnail: ThumbnailRenderer
+      }
+      return (
+        <div>
+          <h4 className="sc-font-l">Flat Custom list</h4>
+          <blockquote>
+            Flat list of items w/ customized renderer<br />
+            <br />
+          </blockquote>
+          <div style={{ display: 'flex' }}>
+            <div style={{ width: '100%', maxWidth: '500px', marginRight: '2em' }}>
+              <Autocomplete
+                source={{
+                  ...props.source,
+                  customRenderer: store.state.renderer ? (renderers as any)[store.state.renderer] : undefined
+                }}
+                selected={store.state.selected}
+                onChange={action('search term changed')}
+                onSelect={i => {
+                  store.set({ selected: i })
+                  action(`entry selected`)(i)
+                }}
+                disabled={boolean('disabled', false)}
+                placeholder={text('placeholder', props.placeholder)}
+                suppressErrors={boolean('suppressErrors', false)}
+                errorMessage={text('errorMessage', 'no matches for term')}
+                hideArrow={boolean('hideArrow', false)}
+              />
+            </div>
+            <div>
+              Renderer: You can provide a custom renderer that will be used to render each of the items in the list.
+              <br />
+              <br />
+              <div style={{ display: 'flex' }}>
+                <input
+                  type="radio"
+                  id="icon"
+                  name="renderer"
+                  checked={store.state.renderer === 'icon'}
+                  onClick={() => store.set({ renderer: 'icon' })}
+                />
+                <label htmlFor="icon">
+                  {IconizedRenderer({
+                    onClick: () => {
+                      /**/
+                    },
+                    search: '',
+                    selected: false,
+                    item: flatData[0]
+                  })}
+                </label>
+              </div>
+              <br />
+              <div style={{ display: 'flex' }}>
+                <input
+                  type="radio"
+                  id="thumb"
+                  name="renderer"
+                  onClick={() => store.set({ renderer: 'thumbnail' })}
+                  checked={store.state.renderer === 'thumbnail'}
+                />
+                <label htmlFor="thumb">
+                  {ThumbnailRenderer({
+                    onClick: () => {
+                      /**/
+                    },
+                    search: '',
+                    selected: false,
+                    item: flatData[0]
+                  })}
+                </label>
+              </div>
+              <br />
+              <div style={{ display: 'flex' }}>
+                <input
+                  type="radio"
+                  id="thumb"
+                  name="renderer"
+                  onClick={() => store.set({ renderer: undefined })}
+                  checked={store.state.renderer === undefined}
+                />
+                <label htmlFor="thumb"> Default renderer </label>
+              </div>
+            </div>
+          </div>
+        </div>
+      )
+    })
   )
   .add(
     'Relational List',

--- a/stories/autocomplete/data.ts
+++ b/stories/autocomplete/data.ts
@@ -1,0 +1,121 @@
+export const flat = [
+  {
+    id: 1,
+    label: 'john',
+    avatar: 'https://wiki.teamfortress.com/w/images/6/67/Scoutava.jpg'
+  },
+  {
+    id: 2,
+    label: 'johnny',
+    avatar: 'https://wiki.teamfortress.com/w/images/f/f2/Soldierava.jpg'
+  },
+  {
+    id: 3,
+    label: 'joe',
+    avatar: 'https://wiki.teamfortress.com/w/images/4/4b/Demomanava.jpg'
+  },
+  {
+    id: 4,
+    label: 'johnannes',
+    avatar: 'https://wiki.teamfortress.com/w/images/5/5e/Heavyava.jpg'
+  },
+  {
+    id: 5,
+    label: 'mike',
+    avatar: 'https://wiki.teamfortress.com/w/images/7/7f/Medicava.jpg'
+  },
+  {
+    id: 6,
+    label: 'steve',
+    avatar: 'https://wiki.teamfortress.com/w/images/4/44/Sniperava.jpg'
+  },
+  {
+    id: 7,
+    label: 'peter',
+    avatar: 'https://wiki.teamfortress.com/w/images/3/37/Spyava.jpg'
+  }
+]
+
+export const group = [
+  {
+    label: 'J names',
+    items: [
+      {
+        id: 1,
+        label: 'john'
+      },
+      {
+        id: 2,
+        label: 'johnny'
+      },
+      {
+        id: 3,
+        label: 'joe'
+      },
+      {
+        id: 4,
+        label: 'johnannes'
+      }
+    ]
+  },
+  {
+    label: 'Other names',
+    items: [
+      {
+        id: 5,
+        label: 'mike'
+      },
+      {
+        id: 6,
+        label: 'steve'
+      },
+      {
+        id: 7,
+        label: 'peter'
+      }
+    ]
+  }
+]
+
+export const relational = [
+  {
+    id: -1,
+    label: 'Aaron'
+  },
+  {
+    id: 0,
+    label: 'Jay (all J belong to me)'
+  },
+  {
+    id: 1,
+    label: 'john',
+    parentId: 0
+  },
+  {
+    id: 2,
+    label: 'johnny',
+    parentId: 0
+  },
+  {
+    id: 3,
+    label: 'joe',
+    parentId: 0
+  },
+  {
+    id: 4,
+    label: 'johnannes',
+    parentId: 0
+  },
+  {
+    id: 5,
+    label: 'mike'
+  },
+  {
+    id: 6,
+    label: 'steve'
+  },
+  {
+    id: 7,
+    label: 'peter'
+  }
+]


### PR DESCRIPTION
# Description:

- Update the FlatList component to support a custom renderer instead of the usual text based one. 
- Add example story

TODO:

- [ ] Introduce markdown renderer so we can use markdown inside stories
- [ ] Export partially-applied autocomplete component for FlatList/RelationalList/GroupList cases, so user doesn't have to deal with input type string